### PR TITLE
Fix audio-related crashes

### DIFF
--- a/src/audio/heap.c
+++ b/src/audio/heap.c
@@ -1116,16 +1116,14 @@ void audio_reset_session(void) {
     s32 temporaryMem;
     s32 totalMem;
     s32 wantMisc;
-#if defined(VERSION_JP) || defined(VERSION_US)
-    s32 frames;
-    s32 remainingDmas;
-#else
+#if defined(VERSION_EU) || defined(VERSION_SH) || defined(VERSION_CN)
     struct SynthesisReverb *reverb;
 #endif
     eu_stubbed_printf_1("Heap Reconstruct Start %x\n", gAudioResetPresetIdToLoad);
 
 #if defined(VERSION_JP) || defined(VERSION_US)
     if (gAudioLoadLock != AUDIO_LOCK_UNINITIALIZED) {
+	    s32 frames;
         decrease_reverb_gain();
         for (i = 0; i < gMaxSimultaneousNotes; i++) {
             if (gNotes[i].enabled && gNotes[i].adsr.state != ADSR_STATE_DISABLED) {
@@ -1166,13 +1164,15 @@ void audio_reset_session(void) {
         gAudioLoadLock = AUDIO_LOCK_LOADING;
         wait_for_audio_frames(3);
 
-        remainingDmas = gCurrAudioFrameDmaCount;
+        #ifdef TARGET_N64
+	s32 remainingDmas = gCurrAudioFrameDmaCount;
         while (remainingDmas > 0) {
             for (i = 0; i < gCurrAudioFrameDmaCount; i++) {
                 if (osRecvMesg(&gCurrAudioFrameDmaQueue, NULL, OS_MESG_NOBLOCK) == 0)
                     remainingDmas--;
             }
         }
+        #endif
         gCurrAudioFrameDmaCount = 0;
 
         for (j = 0; j < NUMAIBUFFERS; j++) {


### PR DESCRIPTION
Merge audio-related patches from https://github.com/AloUltraExt/sm64ex-alo/issues/73#issuecomment-2550390829 which result in a near 100% chance of a crash when remaining within a course for over 30 minutes